### PR TITLE
Fixed time travel with conditional state fields

### DIFF
--- a/package/timeJump.js
+++ b/package/timeJump.js
@@ -16,7 +16,14 @@ module.exports = (origin, mode) => {
     const originNode = traverseTree(origin.tree, coords);
     // set the state of the origin tree if the component is stateful
     if (originNode.component.setState) {
-      originNode.component.setState(target.state, () => {
+      originNode.component.setState((prevState) => {
+        Object.keys(prevState).forEach((key) => {
+          if (target.state[key] === undefined) {
+            target.state[key] = undefined;
+          }
+        })
+        return target.state;
+      }, () => {
         // iterate through new children once state has been set
         target.children.forEach((child, i) => {
           jump(child, coords.concat(i));


### PR DESCRIPTION
Addresses Issue #157:

In `jump()` function inside of `timeJump.js`, updated `setState` call to check for conditionally populated state fields.  