### PR TITLE
Resolved errors with state object in snapshot tree

### DIFF
--- a/dev-reactime/linkFiber.js
+++ b/dev-reactime/linkFiber.js
@@ -121,7 +121,7 @@ module.exports = (snap, mode) => {
       // Save component's state and setState() function to our record for future
       // time-travel state changing. Add record index to snapshot so we can retrieve.
       componentData.index = componentActionsRecord.saveNew(stateNode.state, stateNode);
-      newState = {state: stateNode.state};
+      newState = stateNode.state;
       componentFound = true;
     }
 
@@ -147,18 +147,6 @@ module.exports = (snap, mode) => {
           }
           componentFound = true;
         });
-      }
-    } else {
-      console.log('in create tree else')
-      console.log('this is currentFiber from createTree', currentFiber)
-      console.log('this is memoizedState from createTree', memoizedState)
-      // grab stateless components here
-      if(elementType){
-        if(elementType.name){
-          tree.appendChild('stateless', elementType.name, index);
-        } else {
-          tree.appendChild('stateless', elementType, index);
-        }
       }
     }
 
@@ -233,7 +221,6 @@ module.exports = (snap, mode) => {
 
   // ! BUG: skips 1st hook click
   function updateSnapShotTree() {
-<<<<<<< HEAD
     /* let current;
     // If concurrent mode, grab current.child
     if (concurrent) {

--- a/dev-reactime/linkFiber.js
+++ b/dev-reactime/linkFiber.js
@@ -116,7 +116,7 @@ module.exports = (snap, mode) => {
       // Save component's state and setState() function to our record for future
       // time-travel state changing. Add record index to snapshot so we can retrieve.
       componentData.index = componentActionsRecord.saveNew(stateNode.state, stateNode);
-      newState.state = stateNode.state;
+      newState = {state: stateNode.state};
       componentFound = true;
     }
 


### PR DESCRIPTION
## Description:
- Fixed errors where keys were double nested in state snapshot.

## Changes I Made:
- Fixed state assignment in linkFiber.

## How to Test:
- Standard application test should now properly time-travel with setState.