### PR TITLE
Changed helpers.js to allow for recoil state to flow to Reactime App

### DIFF
--- a/src/backend/helpers.js
+++ b/src/backend/helpers.js
@@ -45,7 +45,7 @@ export const throttle = (f, t) => {
 };
 
 // Helper function to grab the getters/setters from `elementType`
-export const getHooksNames = elementType => {
+export const getHooksNames = (elementType) => {
   // Initialize empty object to store the setters and getter
   let ast;
   try {
@@ -65,21 +65,22 @@ export const getHooksNames = elementType => {
      * Other types: "BlockStatement" / "ExpressionStatement" / "ReturnStatement"
      * Iterate through AST of every function declaration
      * Check within each function declaration if there are hook declarations */
-    ast.forEach(functionDec => {
+    ast.forEach((functionDec) => {
       let body;
-      if (functionDec.expression && functionDec.expression.body) body = functionDec.expression.body.body;
+      if (functionDec.expression && functionDec.expression.body)
+        body = functionDec.expression.body.body;
       else body = functionDec.body ? functionDec.body.body : [];
       // Traverse through the function's funcDecs and Expression Statements
-      body.forEach(elem => {
+      body.forEach((elem) => {
         if (elem.type === 'VariableDeclaration') {
-          elem.declarations.forEach(hook => {
+          elem.declarations.forEach((hook) => {
             // * TypeScript hooks appear to have no "VariableDeclarator"
             // * with id.name of _useState, _useState2, etc...
             // * hook.id.type relevant for TypeScript applications
             // *
             // * Works for useState hooks
             if (hook.id.type === 'ArrayPattern') {
-              hook.id.elements.forEach(hook => {
+              hook.id.elements.forEach((hook) => {
                 statements.push(hook.name);
                 // * Unshift a wildcard name to achieve similar functionality as before
                 statements.unshift(`_useWildcard${tsCount}`);
@@ -92,7 +93,9 @@ export const getHooksNames = elementType => {
                   hooksNames[varName] = hook.id.name;
                 }
               }
-              statements.push(hook.id.name);
+              if (hook.id.name !== undefined) {
+                statements.push(hook.id.name);
+              }
             }
           });
         }


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [x] Bugfix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [ ] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)

## Purpose
<!--- Describe the problem or feature. Link to the issue(s) fixed by this pull request if applicable. -->
Reactime would fail to render any information on Recoil based apps.


## Approach
<!--- How does your change address the problem? -->
Identify an error in helpers.js where unidentified hook id names would not allow Reactime to properly build data tree.


## Learning
<!--- Describe the research stage. Link to any blog posts, video, patterns, libraries, addons, or other resources that helped you to solve this problem. -->
Researched primarily through consoling logging the code and researching React Fiber.


## Screenshot(s)
![Screen Shot 2020-08-17 at 1 03 37 PM](https://user-images.githubusercontent.com/62725736/90439847-170c9d00-e08b-11ea-8c5e-46e97380a95a.png)

<!--- (if applicable--you can delete otherwise) -->
<!--- Include a screenshot here if the change you made changes the look of the site in any way! -->