### PR TITLE
Fix bug in capturing hook names of components with multiple hooks

### DIFF
--- a/src/backend/__tests__/helpers.test.ts
+++ b/src/backend/__tests__/helpers.test.ts
@@ -75,7 +75,7 @@ describe('AST Unit Tests', () => {
       expect(getHooksNames(elementType)).toEqual(['testCount', 'setTestCount']);
     });
 
-    it('Should output the right number of properties when taking in multiple function definitions', () => {
+    it('Should output the right number of properties when given multiple hooks', () => {
       const elementType = `function SingleUseFakeComponent() { 
                             const [testCount, setTestCount] = useState(0);
                             const [biscuitCount, setBiscuitCount] = useState(0);

--- a/src/backend/helpers.ts
+++ b/src/backend/helpers.ts
@@ -91,9 +91,8 @@ export const getHooksNames = (elementType: string): Array<string> => {
             // * Works for useState hooks
             if (hook.id.type === 'ArrayPattern') {
               hook.id.elements.forEach((hook) => {
+                statements.push(`_useWildcard${tsCount}`);
                 statements.push(hook.name);
-                // * Unshift a wildcard name to achieve similar functionality as before
-                statements.unshift(`_useWildcard${tsCount}`);
                 tsCount += 1;
               });
             } else {
@@ -111,7 +110,7 @@ export const getHooksNames = (elementType: string): Array<string> => {
         }
       });
       statements.forEach((el, i) => {
-        if (el.match(/_use/)) hooksNames[el] = statements[i + 2];
+        if (el.match(/_use/)) hooksNames[el] = statements[i + 1];
       });
     });
   }


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [ ] Bugfix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [x] Refactor (change which changes the codebase without affecting its external behavior)
- [x] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)

## Purpose
<!--- Describe the problem or feature. Link to the issue(s) fixed by this pull request if applicable. -->
One of our backend/helper `getHooksNames` unit tests, described below, 
> Should output the right number of properties when given multiple hooks

was failing.

## Approach
<!--- How does your change address the problem? -->
In the spirit of test-driven development, the `getHooksNames` function was modified to fit our test requirement.

We replaced `unshift` with the simpler `push` method to populate `statements` in `getHooksNames` with staggered wildcard strings and their corresponding human-readable state names.
We were not sure why `unshift` was used to handle populating the `statements` array with multiple hook wildcard strings originally. Jury's still out on that.

This change enabled a further simplification when parsing the now-populated `statements` array in that we could iterate over `statements` as usual but store the hook name string _directly adjacent_ to a given wildcard into `hooksNames`, rather than calculate a specific offset dependent on how many hooks we find for a given Fiber. 

Before, the algorithm was brittle because it assumed that there would always only be one hook, and strangely populated the `statements` array backward as the loop came upon more hook names.
This is why the test failed the way it did (see "before change" screenshot).

## Learning
<!--- Describe the research stage. Link to any blog posts, video, patterns, libraries, addons, or other resources that helped you to solve this problem. -->
- Most of the prerequisite learning can be done by referencing [jest docs](https://jestjs.io/docs/en/api) 🃏 
- It's particularly confusing (but important) to get a good grasp of the purpose and exact use cases of [mock](https://www.pluralsight.com/guides/how-does-jest.fn()-work) [functions](https://medium.com/@rickhanlonii/understanding-jest-mocks-f0046c68e53c) -- without an understanding, it's easy to not use them to their fullest potential

## Screenshot(s)
<!--- (if applicable--you can delete otherwise) -->
<!--- Include a screenshot here if the change you made changes the look of the site in any way! -->
### Before change
![image](https://user-images.githubusercontent.com/23015394/91361639-a3b30b80-e7ad-11ea-86fe-55b6709dbe17.png)


### After change
![image](https://user-images.githubusercontent.com/23015394/91361890-1b813600-e7ae-11ea-9226-17330f16cd80.png)