### PR TITLE
Map.tsx overhaul

### DIFF
--- a/src/app/components/Map.tsx
+++ b/src/app/components/Map.tsx
@@ -4,417 +4,282 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 /* eslint-disable @typescript-eslint/ban-types */
 
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useCallback, useState } from 'react';
 import * as d3 from 'd3';
 
-
 const Map = (props) => {
+  //import props
   const { viewIndex, snapshots } = props;
-  
   let lastSnap: number | null = null;
   if (viewIndex < 0) lastSnap = snapshots.length - 1;
   else lastSnap = viewIndex;
-  
-  
+
+  //external constants
   const width: number = 900;
   const height: number = 600;
   let data = snapshots[lastSnap];
-  
 
-  useEffect(() => {
-    document.getElementById('canvas').innerHTML = '_'; 
-    return makeChart(data);
+  const [{ x, y, k }, setZoomState]: any = useState({
+    x: 150,
+    y: 250,
+    k: 0.75,
   });
 
-  const makeChart = React.useCallback ( (data) => {
-    
-    // Establish Constants
-    const margin = { top: 10, right: 120, bottom: 10, left: 120 };
-    const dy = 100;
-    const dx = 100;
-    const tree = d3.tree().nodeSize([dx, dy]);
-    const diagonal = d3
-      .linkHorizontal()
-      .x((d) => d.y)
-      .y((d) => d.x);
-    const root = d3.hierarchy(data);
+  // useEffect(() => {
+  //   setZoomState(d3.zoomTransform(d3.select('#canvas').node()));
+  // }, [data]);
 
-    // Determine descendants of root node use d.depth conditional to how many levels deep to display on first render
-    root.x0 = dy / 2;
-    root.y0 = 0;
-    root.descendants().forEach((d, i) => {
-      d.id = i;
-      d._children = d.children;
-       if (d.depth === 9) d.children = null;
-    });
 
-    
-   // Create Container for D3 Visualizations
-    const svgContainer = d3
-      .select('#canvas')
-      .attr('width', width)
-      .attr('height', height)
+  useEffect(() => {
+    document.getElementById('canvas').innerHTML = '_';
+    setZoomState(d3.zoomTransform(d3.select('#canvas').node()));
+    return makeChart(data);
+  }, [data]);
 
-    // create inner container to help with drag and zoom 
-    const svg: any = svgContainer
-    .append('g')
-    
-    // create links
-    const gLink = svg
-      .append('g')
-      .attr('fill', 'none')
-      .attr('stroke', '#555')
-      .attr('stroke-opacity', 0.9)
-      .attr('stroke-width', 1.5);
+  const makeChart = useCallback(
+    (data) => {
+      // Establish Constants
+      const margin = { top: 10, right: 120, bottom: 10, left: 120 };
+      const dy = 120;
+      const dx = 100;
+      const tree = d3.tree().nodeSize([dx, dy]);
+      const diagonal = d3
+        .linkHorizontal()
+        .x((d) => d.y)
+        .y((d) => d.x);
+      const root = d3.hierarchy(data);
 
-    // create nodes
-    const gNode = svg
-      .append('g')
-      .attr('cursor', 'pointer')
-      .attr('pointer-events', 'all');
-
-    // declare re render funciton to handle collapse and expansion of nodes
-    function update(source) {
-      const duration = d3.event && d3.event.altKey ? 2500 : 250;
-      const nodes = root.descendants().reverse();
-      const links = root.links();
-
-      // Compute the new tree layout.
-      tree(root);
-      let left = root;
-      let right = root;
-      root.eachBefore((node) => {
-        if (node.x < left.x) left = node;
-        if (node.x > right.x) right = node;
+      // Determine descendants of root node use d.depth conditional to how many levels deep to display on first render
+      root.x0 = dy / 2;
+      root.y0 = 0;
+      root.descendants().forEach((d, i) => {
+        d.id = i;
+        d._children = d.children;
+        if (d.depth === 9) d.children = null;
       });
 
-      //use nodes to detrmine height
-      const height = right.x - left.x + margin.top + margin.bottom;
+      // Create Container for D3 Visualizations
+      const svgContainer = d3
+        .select('#canvas')
+        .attr('width', width)
+        .attr('height', height);
 
-      // transition between past and present
-      const transition = svg
-        .transition()
-        .duration(duration)
-        .attr('viewBox', [-margin.left, left.x - margin.top, width, height])
-       ;
-
-      // Update the nodes…
-      const node = gNode.selectAll('g').data(nodes, (d) => d.id);
-
-      // Enter any new nodes at the parent's previous position.
-      const nodeEnter = node
-        .enter()
+      // create inner container to help with drag and zoom
+      const svg: any = svgContainer
         .append('g')
-        .attr('transform', (d) => `translate(${source.y0},${source.x0})`)
-        .attr('fill-opacity', 0)
-        .attr('stroke-opacity', 1)
-        .on('click', (d) => {
-          d.children = d.children ? null : d._children;
-          update(d);
+        .attr('transform', `translate(${x}, ${y}), scale(${k})`); // sets the canvas to the saved zoomState
+
+      // create links
+      const gLink = svg
+        .append('g')
+        .attr('fill', 'none')
+        .attr('stroke', '#555')
+        .attr('stroke-opacity', 0.9)
+        .attr('stroke-width', 1.5);
+
+      // create nodes
+      const gNode = svg
+        .append('g')
+        .attr('cursor', 'pointer')
+        .attr('pointer-events', 'all');
+
+      // declare re render funciton to handle collapse and expansion of nodes
+      const update = (source) => {
+        const duration = 0;
+        const nodes = root.descendants().reverse();
+        const links = root.links();
+
+        // Compute the new tree layout.
+        tree(root);
+        let left = root;
+        let right = root;
+        root.eachBefore((node) => {
+          if (node.x < left.x) left = node;
+          if (node.x > right.x) right = node;
         });
-      
-      // paint circles, color based on children
-      nodeEnter
-        .append('circle')
-        .attr('r', 10)
-        .attr('fill', (d) => (d._children ?  '#46edf2': '#95B6B7' ))
-        .attr('stroke-width', 10)
-        .attr('stroke-opacity', 1);
-      
-      // append node names
-      nodeEnter
-      .append('text')
+
+        //use nodes to detrmine height
+        const height = right.x - left.x + margin.top + margin.bottom;
+
+        const transition = svg
+          .transition()
+          .duration(duration)
+          .attr('viewBox', [-margin.left, left.x - margin.top, width, height]);
+        // Update the nodes…
+        const node = gNode.selectAll('g').data(nodes, (d) => d.id);
+
+        // Enter any new nodes at the parent's previous position.
+        const nodeEnter = node
+          .enter()
+          .append('g')
+          .attr('transform', (d) => `translate(${source.y0},${source.x0})`)
+          .attr('fill-opacity', 0)
+          .attr('stroke-opacity', 1)
+          .on('click', (d) => {
+            d.children = d.children ? null : d._children;
+            update(d);
+          });
+
+        // paint circles, color based on children
+        nodeEnter
+          .append('circle')
+          .attr('r', 10)
+          .attr('fill', (d) => (d._children ? '#46edf2' : '#95B6B7'))
+          .attr('stroke-width', 10)
+          .attr('stroke-opacity', 1);
+
+        // append node names
+        nodeEnter
+          .append('text')
           .attr('dy', '.31em')
           .attr('x', '-10')
           .attr('y', '-5')
-          .attr('text-anchor','end' )
-          .text((d: any) => d.data.name.slice(0,14))
+          .attr('text-anchor', 'end')
+          .text((d: any) => d.data.name.slice(0, 14)) // Limits Characters in Display
           .style('font-size', `.6rem`)
           .style('fill', 'white')
           .clone(true)
           .lower()
-          .attr("stroke-linejoin", "round")
+          .attr('stroke-linejoin', 'round')
           .attr('stroke', '#646464')
           .attr('stroke-width', 1);
 
-             // display the data in the node on hover
-             
-      nodeEnter.on('mouseover', function (d: any, i: number): any {
-        if (!d.children) {
-          d3.select(this)
-            .append('text')
-            .text(()=>{
-              console.log(d)
-              return JSON.stringify(d.data)})
-            .style('fill', 'white')
-            .attr('x',0)
-            .attr('y', 0)
-            .style('font-size', '.6rem')
-            .style('text-align', 'center')
-            .attr('stroke', '#646464')
-            .attr('id', `popup${i}`);
-         }
-      });
-      
-      nodeEnter.on('mouseout', function (d: any, i: number): any {
-        d3.select(`#popup${i}`).remove();
-      });
-        
-      // Transition nodes to their new position.
-      const nodeUpdate = node
-        .merge(nodeEnter)
-        .transition(transition)
-        .attr('transform', (d) => `translate(${d.y},${d.x})`)
-        .attr('fill-opacity', 1)
-        .attr('stroke-opacity', 1);
+        //TODO -> Alter incoming snapshots so there is useful data to show on hover.
+        // nodeEnter.on('mouseover', function (d: any, i: number): any {
+        //   if (!d.children) {
+        //     d3.select(this)
+        //       .append('text')
+        //       .text(()=>{
+        //         return JSON.stringify(d.data)})
+        //       .style('fill', 'white')
+        //       .attr('x',0)
+        //       .attr('y', 0)
+        //       .style('font-size', '.6rem')
+        //       .style('text-align', 'center')
+        //       .attr('stroke', '#646464')
+        //       .attr('id', `popup${i}`);
+        //    }
+        // });
+        // nodeEnter.on('mouseout', function (d: any, i: number): any {
+        //   d3.select(`#popup${i}`).remove();
+        // });
 
-      // Transition exiting nodes to the parent's new position.
-      const nodeExit = node
-        .exit()
-        .transition(transition)
-        .remove()
-        .attr('transform', (d) => `translate(${source.y},${source.x})`)
-        .attr('fill-opacity', 0)
-        .attr('stroke-opacity', 0);
+        // Transition nodes to their new position.
+        const nodeUpdate = node
+          .merge(nodeEnter)
+          .transition(transition)
+          .attr('transform', (d) => `translate(${d.y},${d.x})`)
+          .attr('fill-opacity', 1)
+          .attr('stroke-opacity', 1);
 
-      // Update the links…
-      const link = gLink.selectAll('path').data(links, (d) => d.target.id);
+        // Transition exiting nodes to the parent's new position.
+        const nodeExit = node
+          .exit()
+          .transition(transition)
+          .remove()
+          .attr('transform', (d) => `translate(${source.y},${source.x})`)
+          .attr('fill-opacity', 0)
+          .attr('stroke-opacity', 0);
 
-      // Enter any new links at the parent's previous position.
-      const linkEnter = link
-        .enter()
-        .append('path')
-        .attr('d', (d) => {
-          const o = { x: source.x0, y: source.y0 };
-          return diagonal({ source: o, target: o });
+        // Update the links…
+        const link = gLink.selectAll('path').data(links, (d) => d.target.id);
+
+        // Enter any new links at the parent's previous position.
+        const linkEnter = link
+          .enter()
+          .append('path')
+          .attr('d', (d) => {
+            const o = { x: source.x0, y: source.y0 };
+            return diagonal({ source: o, target: o });
+          });
+
+        // Transition links to their new position.
+        link.merge(linkEnter).transition(transition).attr('d', diagonal);
+
+        // Transition exiting nodes to the parent's new position.
+        link
+          .exit()
+          .transition(transition)
+          .remove()
+          .attr('d', (d) => {
+            const o = { x: source.x, y: source.y };
+            return diagonal({ source: o, target: o });
+          });
+
+        // Stash the old positions for transition.
+        root.eachBefore((d) => {
+          d.x0 = d.x;
+          d.y0 = d.y;
         });
+      };
 
-      // Transition links to their new position.
-      link.merge(linkEnter).transition(transition).attr('d', diagonal);
+      //______________ZOOM______________\\
 
-      // Transition exiting nodes to the parent's new position.
-      link
-        .exit()
-        .transition(transition)
-        .remove()
-        .attr('d', (d) => {
-          const o = { x: source.x, y: source.y };
-          return diagonal({ source: o, target: o });
-        });
+      // Sets starting zoom
+      let zoom = d3.zoom().on('zoom', zoomed);
 
-      // Stash the old positions for transition.
-      root.eachBefore((d) => {
-        d.x0 = d.x;
-        d.y0 = d.y;
-      });
+      svgContainer.call(
+        zoom.transform,
+        // Changes the initial view, (left, top)
+        d3.zoomIdentity.translate(x, y).scale(k)
+      );
 
-    }
-  
-         //______________ZOOM______________\\
-
-    // Sets starting zoom 
-    let zoom = d3.zoom().on('zoom', zoomed);
-    svgContainer.call(
-      zoom.transform,
-      // Changes the initial view, (left, top)
-      d3.zoomIdentity.translate(150, 250).scale(0.6)
-    );
-
-    // allows the canvas to be zoom-able
-    svgContainer.call(
-      d3
-        .zoom()
-        .scaleExtent([0.15, 1.5]) // [zoomOut, zoomIn]
-        .on('zoom', zoomed)
-    );
-    function zoomed(d: any) {
-      svg.attr('transform', d3.event.transform);
-    }
+      // allows the canvas to be zoom-able
+      svgContainer.call(
+        d3
+          .zoom()
+          .scaleExtent([0.15, 1.5]) // [zoomOut, zoomIn]
+          .on('zoom', zoomed)
+          
+      );
+      function zoomed(d: any) {
+        svg.attr('transform', d3.event.transform)
+        .on('mouseup', setZoomState(d3.zoomTransform(d3.select('#canvas').node()))
+        );
+      }
 
       // allows the canvas to be draggable
-    svg.call(
-      d3
-        .drag()
-        .on('start', dragStarted)
-        .on('drag', dragged)
-        .on('end', dragEnded)
-    );
-    function dragStarted(): any {
-      d3.select(this).raise();
-     svg.attr('cursor', 'grabbing');
-    }
-    function dragged(d: any): any {
-      d3.select(this)
-        .attr('dx', (d.x = d3.event.x))
-        .attr('dy', (d.y = d3.event.y));
-    }
-    function dragEnded(): any {
-      svg.attr('cursor', 'grab');
-    }
-    
-    // call update on node click
-    update(root);
-  }, [data]);
-  // // set the heights and width of the tree to be passed into treeMap function
-  // const width: number = 900;
-  // const height: number = 600;
+      svg.call(
+        d3
+          .drag()
+         
+      );
+      // function dragStarted(): any {
+      //   d3.select(this).raise();
+      //   svg.attr('cursor', 'grabbing');
+      // }
+      // function dragged(d: any): any {
+      //   d3.select(this)
+      //     .attr('dx', (d.x = d3.event.x))
+      //     .attr('dy', (d.y = d3.event.y));
+      // }
+      // function dragEnded(): any {
+      //   svg.attr('cursor', 'grab');
+      // }
 
-  // // this state allows the canvas to stay at the zoom level on multiple re-renders
-  // const [{ x, y, k }, setZoomState]: any = useState({ x: 0, y: 0, k: 0 });
-  // useEffect(() => {
-  //   setZoomState(d3.zoomTransform(d3.select('#canvas').node()));
-  // }, [snapshot.children]);
+      // Zoom Data from Canvas
 
-  // // Create D3 Tree Diagram
-  // useEffect(() => {
+      // let test: any = document.getElementById('canvas').children[0];
+      // console.log('from canvas', test.transform);
+      // let newX = test.transform.baseVal[0].matrix.e
+      // let newY = test.transform.baseVal[0].matrix.f
+      // let newK = test.transform.baseVal[1].matrix.a
+      // console.log(newX)
+      // console.log(newY)
+      // console.log(newK)
 
-  //   document.getElementById('canvas').innerHTML = '';
-
-  //   // creating the main svg container for d3 elements
-  //   const svgContainer: any = d3
-  //     .select('#canvas')
-  //     .attr('width', width)
-  //     .attr('height', height);
-
-  //   // creating a pseudo-class for reusability
-  //   const g: any = svgContainer
-  //     .append('g')
-  //     .attr('transform', `translate(${x}, ${y}), scale(${k})`); // sets the canvas to the saved zoomState
-
-  //   // creating the tree map
-  //   const treeMap: any = d3.tree().nodeSize([width, height]);
-  //   // creating the nodes of the tree
-  //   const hierarchyNodes: any = d3.hierarchy(snapshots[lastSnap]);
-  //   // calling the tree function with nodes created from data
-  //   const finalMap: any = treeMap(hierarchyNodes);
-  //   // renders the paths onto the component
-
-  //   let paths: any = finalMap.links();
-  //   // returns a flat array of objects containing all the nodes and their information
-  //   let nodes: any = hierarchyNodes.descendants();
-
-  //   // this creates the paths to each node and its contents in the tree
-  //   g.append('g')
-  //     .attr('fill', 'none')
-  //     .attr('stroke', '#646464')
-  //     .attr('stroke-width', 5)
-  //     .selectAll('path')
-  //     .data(paths)
-  //     .enter()
-  //     .append('path')
-  //     .attr(
-  //       'd',
-  //       d3
-  //         .linkHorizontal()
-  //         .x((d: any) => d.y)
-  //         .y((d: any) => d.x)
-  //     );
-
-  //   // this segment places all the nodes on the canvas
-  //   const node: any = g
-  //     .append('g')
-  //     .attr('stroke-linejoin', 'round') // no clue what this does
-  //     .attr('stroke-width', 1)
-  //     .selectAll('g')
-  //     .data(nodes)
-  //     .enter()
-  //     .append('g')
-  //     .attr('transform', (d: any) => `translate(${d.y}, ${d.x})`)
-  //     .attr('class', 'atomNodes');
-
-  //   // for each node that got created, append a circle element
-  //   node
-  //     .append('circle')
-  //     .attr('fill', (d: any) => (d.children ? '#95B6B7' : '#46edf2'))
-  //     .attr('r', 50);
-
-  //   // for each node that got created, append a text element that displays the name of the node
-  //   node
-  //     .append('text')
-  //     .attr('dy', '.31em')
-  //     .attr('x', (d: any) => (d.children ? -50 : 50))
-  //     .attr('text-anchor', (d: any) => (d.children ? 'end' : 'start'))
-  //     .text((d: any) => d.data.name)
-  //     .style('font-size', `2rem`)
-  //     .style('fill', 'white')
-  //     .clone(true)
-  //     .lower()
-  //     .attr('stroke', '#646464')
-  //     .attr('stroke-width', 2);
-
-  //   // display the data in the node on hover
-  //   node.on('mouseover', function (d: any, i: number): any {
-  //     if (!d.children) {
-  //       d3.select(this)
-  //         .append('text')
-  //         .text(JSON.stringify(d.data, undefined, 2))
-  //         .style('fill', 'white')
-  //         .attr('x', -999)
-  //         .attr('y', 100)
-  //         .style('font-size', '3rem')
-  //         .style('text-align', 'center')
-  //         .attr('stroke', '#646464')
-  //         .attr('id', `popup${i}`);
-  //     }
-  //   });
-
-  //   // add mouseOut event handler that removes the popup text
-  //   node.on('mouseout', function (d: any, i: number): any {
-  //     d3.select(`#popup${i}`).remove();
-  //   });
-
-  //   //______________ZOOM______________\\
-
-  //   // Sets starting zoom but breaks keeping currents zoom on state change
-
-  //   // let zoom = d3.zoom().on('zoom', zoomed);
-  //   // svgContainer.call(
-  //   //   zoom.transform,
-  //   //   // Changes the initial view, (left, top)
-  //   //   d3.zoomIdentity.translate(150, 250).scale(0.2)
-  //   // );
-
-  //   // allows the canvas to be zoom-able
-  //   svgContainer.call(
-  //     d3
-  //       .zoom()
-  //       .scaleExtent([0.05, 0.9]) // [zoomOut, zoomIn]
-  //       .on('zoom', zoomed)
-  //   );
-  //   function zoomed(d: any) {
-  //     g.attr('transform', d3.event.transform);
-  //   }
-
-  //   //_____________DRAG_____________\\
-  //   // allows the canvas to be draggable
-  //   node.call(
-  //     d3
-  //       .drag()
-  //       .on('start', dragStarted)
-  //       .on('drag', dragged)
-  //       .on('end', dragEnded)
-  //   );
-
-  //   function dragStarted(): any {
-  //     d3.select(this).raise();
-  //     g.attr('cursor', 'grabbing');
-  //   }
-  //   function dragged(d: any): any {
-  //     d3.select(this)
-  //       .attr('dx', (d.x = d3.event.x))
-  //       .attr('dy', (d.y = d3.event.y));
-  //   }
-  //   function dragEnded(): any {
-  //     g.attr('cursor', 'grab');
-  //   }
-  // });
+      // call update on node click
+      update(root);
+    },
+    [data]
+  );
 
   return (
     <div data-testid="canvas">
-  
-        <svg id="canvas"></svg>
-      </div>
-   
+      <svg
+        id="canvas"
+      ></svg>
+    </div>
   );
 };
 

--- a/src/app/components/Map.tsx
+++ b/src/app/components/Map.tsx
@@ -7,123 +7,187 @@
 import React, { useState, useEffect } from 'react';
 import * as d3 from 'd3';
 
+
 const Map = (props) => {
+  const { snapshot, snapshots } = props;
+  const lastSnap = snapshots.length - 1;
+
+  let width = 1800;
+  let height = 900;
+  let margin = { top: 10, right: 120, bottom: 10, left: 120 };
+  let dy = 100;
+  let dx = 76;
+  let data = snapshots[lastSnap];
+  let tree = d3.tree().nodeSize([dx, dy]);
+  let diagonal = d3
+    .linkHorizontal()
+    .x((d) => d.y)
+    .y((d) => d.x);
+
  
-  const { snapshot, snapshots} = props;
-  const lastSnap = snapshots.length -1
 
-  // set the heights and width of the tree to be passed into treeMap function
-  const width: number = 900;
-  const height: number = 600;
-
-  // this state allows the canvas to stay at the zoom level on multiple re-renders
-  const [{ x, y, k }, setZoomState]: any = useState({ x: 0, y: 0, k: 0 });
   useEffect(() => {
-    setZoomState(d3.zoomTransform(d3.select('#canvas').node()));
-  }, [snapshot.children]);
+    
+    return makeChart();
+  });
 
-  // Create D3 Tree Diagram
-  useEffect(() => {
-
+  const makeChart = () => {
     document.getElementById('canvas').innerHTML = '';
 
-    // creating the main svg container for d3 elements
-    const svgContainer: any = d3
-      .select('#canvas')
+    const root = d3.hierarchy(data);
+
+    root.x0 = dy / 2;
+    root.y0 = 0;
+    root.descendants().forEach((d, i) => {
+      d.id = i;
+      d._children = d.children;
+      // if (d.depth && d.data.name.length !== 7) d.children = null;
+    });
+
+    console.log("root", root)
+    // const svgContainer: any = d3
+    //   .select('#canvas')
+    //   .attr('width', width)
+    //   .attr('height', height);
+
+    // const svg = d3
+    //   .create('svg')
+    //   .attr('viewBox', [-margin.left, -margin.top, width, dx])
+    //   .style('font', '10px sans-serif')
+    //   .style('user-select', 'none');
+
+    const svg = d3
+       .select('#canvas')
       .attr('width', width)
-      .attr('height', height);
+      .attr('height', height)
+    //   .attr('viewBox', [-margin.left, -margin.top, width, dx])
+    // .style('font', '10px sans-serif')
+    //   .style('user-select', 'none');
 
-    // creating a pseudo-class for reusability
-    const g: any = svgContainer
+    const gLink = svg
       .append('g')
-      .attr('transform', `translate(${x}, ${y}), scale(${k})`); // sets the canvas to the saved zoomState
-
-    // creating the tree map
-    const treeMap: any = d3.tree().nodeSize([width, height]);
-    // creating the nodes of the tree
-    const hierarchyNodes: any = d3.hierarchy(snapshots[lastSnap]);
-    // calling the tree function with nodes created from data
-    const finalMap: any = treeMap(hierarchyNodes);
-    // renders the paths onto the component
-    let paths: any = finalMap.links();
-    // returns a flat array of objects containing all the nodes and their information
-    let nodes: any = hierarchyNodes.descendants();
-
-    // this creates the paths to each node and its contents in the tree
-    g.append('g')
       .attr('fill', 'none')
-      .attr('stroke', '#646464')
-      .attr('stroke-width', 5)
-      .selectAll('path')
-      .data(paths)
-      .enter()
-      .append('path')
-      .attr(
-        'd',
-        d3
-          .linkHorizontal()
-          .x((d: any) => d.y)
-          .y((d: any) => d.x)
-      );
+      .attr('stroke', '#555')
+      .attr('stroke-opacity', 0.4)
+      .attr('stroke-width', 1.5);
 
-  
-
-    // this segment places all the nodes on the canvas
-    const node: any = g
+    const gNode = svg
       .append('g')
-      .attr('stroke-linejoin', 'round') // no clue what this does
-      .attr('stroke-width', 1)
-      .selectAll('g')
-      .data(nodes)
-      .enter()
-      .append('g')
-      .attr('transform', (d: any) => `translate(${d.y}, ${d.x})`)
-      .attr('class', 'atomNodes');
+      .attr('cursor', 'pointer')
+      .attr('pointer-events', 'all');
 
-    // for each node that got created, append a circle element
-    node
-      .append('circle')
-      .attr('fill', (d: any) => (d.children ? '#95B6B7' : '#46edf2'))
-      .attr('r', 50);
+    function update(source) {
+      const duration = d3.event && d3.event.altKey ? 2500 : 250;
+      const nodes = root.descendants().reverse();
+      const links = root.links();
 
-    // for each node that got created, append a text element that displays the name of the node
-    node
+      // Compute the new tree layout.
+      tree(root);
+
+      console.log("tree",tree(root))
+      let left = root;
+      let right = root;
+      root.eachBefore((node) => {
+        if (node.x < left.x) left = node;
+        if (node.x > right.x) right = node;
+      });
+
+      const height = right.x - left.x + margin.top + margin.bottom;
+
+      const transition = svg
+        .transition()
+        .duration(duration)
+        .attr('viewBox', [-margin.left, left.x - margin.top, width, height])
+       ;
+
+      // Update the nodes…
+      const node = gNode.selectAll('g').data(nodes, (d) => d.id);
+
+      // Enter any new nodes at the parent's previous position.
+      const nodeEnter = node
+        .enter()
+        .append('g')
+        .attr('transform', (d) => `translate(${source.y0},${source.x0})`)
+        .attr('fill-opacity', 0)
+        .attr('stroke-linejoin', 'round')
+        .attr('stroke-opacity', 1)
+        .on('click', (d) => {
+          d.children = d.children ? null : d._children;
+          update(d);
+        });
+
+      nodeEnter
+        .append('circle')
+        .attr('r', 15)
+        .attr('fill', (d) => (d._children ?  '#46edf2': '#95B6B7' ))
+        .attr('stroke-linejoin', 'round')
+        .attr('stroke-width', 10);
+       
+
+      nodeEnter
       .append('text')
-      .attr('dy', '.31em')
-      .attr('x', (d: any) => (d.children ? -50 : 50))
-      .attr('text-anchor', (d: any) => (d.children ? 'end' : 'start'))
-      .text((d: any) => d.data.name)
-      .style('font-size', `2rem`)
-      .style('fill', 'white')
-      .clone(true)
-      .lower()
-      .attr('stroke', '#646464')
-      .attr('stroke-width', 2);
-
-    // display the data in the node on hover
-    node.on('mouseover', function (d: any, i: number): any {
-      if (!d.children) {
-        d3.select(this)
-          .append('text')
-          .text(JSON.stringify(d.data, undefined, 2))
+          .attr('dy', '.31em')
+          .attr('x', (d: any) => (d.children ? -50 : 50))
+          .attr('text-anchor', (d: any) => (d.children ? 'end' : 'start'))
+          .text((d: any) => d.data.name)
+          .style('font-size', `1rem`)
           .style('fill', 'white')
-          .attr('x', -999)
-          .attr('y', 100)
-          .style('font-size', '3rem')
-          .style('text-align', 'center')
+          .clone(true)
+          .lower()
           .attr('stroke', '#646464')
-          .attr('id', `popup${i}`);
-      }
-    });
+          .attr('stroke-width', 2);
+        
 
-    // add mouseOut event handler that removes the popup text
-    node.on('mouseout', function (d: any, i: number): any {
-      d3.select(`#popup${i}`).remove();
-    });
+        console.log("119")
+      // Transition nodes to their new position.
+      const nodeUpdate = node
+        .merge(nodeEnter)
+        .transition(transition)
+        .attr('transform', (d) => `translate(${d.y},${d.x})`)
+        .attr('fill-opacity', 1)
+        .attr('stroke-opacity', 1);
 
-    
+      // Transition exiting nodes to the parent's new position.
+      const nodeExit = node
+        .exit()
+        .transition(transition)
+        .remove()
+        .attr('transform', (d) => `translate(${source.y},${source.x})`)
+        .attr('fill-opacity', 0)
+        .attr('stroke-opacity', 0);
 
-    //______________ZOOM______________\\
+      // Update the links…
+      const link = gLink.selectAll('path').data(links, (d) => d.target.id);
+
+      // Enter any new links at the parent's previous position.
+      const linkEnter = link
+        .enter()
+        .append('path')
+        .selectAll('path')
+        .attr('d', (d) => {
+          const o = { x: source.x0, y: source.y0 };
+          return diagonal({ source: o, target: o });
+        });
+
+      // Transition links to their new position.
+      link.merge(linkEnter).transition(transition).attr('d', diagonal);
+
+      // Transition exiting nodes to the parent's new position.
+      link
+        .exit()
+        .transition(transition)
+        .remove()
+        .attr('d', (d) => {
+          const o = { x: source.x, y: source.y };
+          return diagonal({ source: o, target: o });
+        });
+
+      // Stash the old positions for transition.
+      root.eachBefore((d) => {
+        d.x0 = d.x;
+        d.y0 = d.y;
+      });
+         //______________ZOOM______________\\
 
     // Sets starting zoom but breaks keeping currents zoom on state change
 
@@ -135,19 +199,19 @@ const Map = (props) => {
     // );
 
     // allows the canvas to be zoom-able
-    svgContainer.call(
+    svg.call(
       d3
         .zoom()
         .scaleExtent([0.05, 0.9]) // [zoomOut, zoomIn]
         .on('zoom', zoomed)
     );
     function zoomed(d: any) {
-      g.attr('transform', d3.event.transform);
+      svg.attr('transform', d3.event.transform);
     }
 
     //_____________DRAG_____________\\
     // allows the canvas to be draggable
-    node.call(
+   svg.call(
       d3
         .drag()
         .on('start', dragStarted)
@@ -157,7 +221,7 @@ const Map = (props) => {
 
     function dragStarted(): any {
       d3.select(this).raise();
-      g.attr('cursor', 'grabbing');
+      svg.attr('cursor', 'grabbing');
     }
     function dragged(d: any): any {
       d3.select(this)
@@ -165,16 +229,175 @@ const Map = (props) => {
         .attr('dy', (d.y = d3.event.y));
     }
     function dragEnded(): any {
-      g.attr('cursor', 'grab');
+      svg.attr('cursor', 'grab');
     }
-  });
+    }
+   
 
+    update(root);
+  };
+  // // set the heights and width of the tree to be passed into treeMap function
+  // const width: number = 900;
+  // const height: number = 600;
+
+  // // this state allows the canvas to stay at the zoom level on multiple re-renders
+  // const [{ x, y, k }, setZoomState]: any = useState({ x: 0, y: 0, k: 0 });
+  // useEffect(() => {
+  //   setZoomState(d3.zoomTransform(d3.select('#canvas').node()));
+  // }, [snapshot.children]);
+
+  // // Create D3 Tree Diagram
+  // useEffect(() => {
+
+  //   document.getElementById('canvas').innerHTML = '';
+
+  //   // creating the main svg container for d3 elements
+  //   const svgContainer: any = d3
+  //     .select('#canvas')
+  //     .attr('width', width)
+  //     .attr('height', height);
+
+  //   // creating a pseudo-class for reusability
+  //   const g: any = svgContainer
+  //     .append('g')
+  //     .attr('transform', `translate(${x}, ${y}), scale(${k})`); // sets the canvas to the saved zoomState
+
+  //   // creating the tree map
+  //   const treeMap: any = d3.tree().nodeSize([width, height]);
+  //   // creating the nodes of the tree
+  //   const hierarchyNodes: any = d3.hierarchy(snapshots[lastSnap]);
+  //   // calling the tree function with nodes created from data
+  //   const finalMap: any = treeMap(hierarchyNodes);
+  //   // renders the paths onto the component
+
+  //   let paths: any = finalMap.links();
+  //   // returns a flat array of objects containing all the nodes and their information
+  //   let nodes: any = hierarchyNodes.descendants();
+
+  //   // this creates the paths to each node and its contents in the tree
+  //   g.append('g')
+  //     .attr('fill', 'none')
+  //     .attr('stroke', '#646464')
+  //     .attr('stroke-width', 5)
+  //     .selectAll('path')
+  //     .data(paths)
+  //     .enter()
+  //     .append('path')
+  //     .attr(
+  //       'd',
+  //       d3
+  //         .linkHorizontal()
+  //         .x((d: any) => d.y)
+  //         .y((d: any) => d.x)
+  //     );
+
+  //   // this segment places all the nodes on the canvas
+  //   const node: any = g
+  //     .append('g')
+  //     .attr('stroke-linejoin', 'round') // no clue what this does
+  //     .attr('stroke-width', 1)
+  //     .selectAll('g')
+  //     .data(nodes)
+  //     .enter()
+  //     .append('g')
+  //     .attr('transform', (d: any) => `translate(${d.y}, ${d.x})`)
+  //     .attr('class', 'atomNodes');
+
+  //   // for each node that got created, append a circle element
+  //   node
+  //     .append('circle')
+  //     .attr('fill', (d: any) => (d.children ? '#95B6B7' : '#46edf2'))
+  //     .attr('r', 50);
+
+  //   // for each node that got created, append a text element that displays the name of the node
+  //   node
+  //     .append('text')
+  //     .attr('dy', '.31em')
+  //     .attr('x', (d: any) => (d.children ? -50 : 50))
+  //     .attr('text-anchor', (d: any) => (d.children ? 'end' : 'start'))
+  //     .text((d: any) => d.data.name)
+  //     .style('font-size', `2rem`)
+  //     .style('fill', 'white')
+  //     .clone(true)
+  //     .lower()
+  //     .attr('stroke', '#646464')
+  //     .attr('stroke-width', 2);
+
+  //   // display the data in the node on hover
+  //   node.on('mouseover', function (d: any, i: number): any {
+  //     if (!d.children) {
+  //       d3.select(this)
+  //         .append('text')
+  //         .text(JSON.stringify(d.data, undefined, 2))
+  //         .style('fill', 'white')
+  //         .attr('x', -999)
+  //         .attr('y', 100)
+  //         .style('font-size', '3rem')
+  //         .style('text-align', 'center')
+  //         .attr('stroke', '#646464')
+  //         .attr('id', `popup${i}`);
+  //     }
+  //   });
+
+  //   // add mouseOut event handler that removes the popup text
+  //   node.on('mouseout', function (d: any, i: number): any {
+  //     d3.select(`#popup${i}`).remove();
+  //   });
+
+  //   //______________ZOOM______________\\
+
+  //   // Sets starting zoom but breaks keeping currents zoom on state change
+
+  //   // let zoom = d3.zoom().on('zoom', zoomed);
+  //   // svgContainer.call(
+  //   //   zoom.transform,
+  //   //   // Changes the initial view, (left, top)
+  //   //   d3.zoomIdentity.translate(150, 250).scale(0.2)
+  //   // );
+
+  //   // allows the canvas to be zoom-able
+  //   svgContainer.call(
+  //     d3
+  //       .zoom()
+  //       .scaleExtent([0.05, 0.9]) // [zoomOut, zoomIn]
+  //       .on('zoom', zoomed)
+  //   );
+  //   function zoomed(d: any) {
+  //     g.attr('transform', d3.event.transform);
+  //   }
+
+  //   //_____________DRAG_____________\\
+  //   // allows the canvas to be draggable
+  //   node.call(
+  //     d3
+  //       .drag()
+  //       .on('start', dragStarted)
+  //       .on('drag', dragged)
+  //       .on('end', dragEnded)
+  //   );
+
+  //   function dragStarted(): any {
+  //     d3.select(this).raise();
+  //     g.attr('cursor', 'grabbing');
+  //   }
+  //   function dragged(d: any): any {
+  //     d3.select(this)
+  //       .attr('dx', (d.x = d3.event.x))
+  //       .attr('dy', (d.y = d3.event.y));
+  //   }
+  //   function dragEnded(): any {
+  //     g.attr('cursor', 'grab');
+  //   }
+  // });
+
+  console.log("Return")
   return (
     <div data-testid="canvas">
-      <div className="Visualizer">
+  
         <svg id="canvas"></svg>
+        hi
       </div>
-    </div>
+   
   );
 };
 

--- a/src/app/components/Map.tsx
+++ b/src/app/components/Map.tsx
@@ -44,7 +44,8 @@ const Map = (props) => {
       root.descendants().forEach((d, i) => {
         d.id = i;
         d._children = d.children;
-        if (d.depth === 9) d.children = null;
+        // use to limit depth of children rendered
+        //if (d.depth === 5) d.children = null;
       });
 
       // Create Container for D3 Visualizations
@@ -233,29 +234,7 @@ const Map = (props) => {
           .drag()
          
       );
-      // function dragStarted(): any {
-      //   d3.select(this).raise();
-      //   svg.attr('cursor', 'grabbing');
-      // }
-      // function dragged(d: any): any {
-      //   d3.select(this)
-      //     .attr('dx', (d.x = d3.event.x))
-      //     .attr('dy', (d.y = d3.event.y));
-      // }
-      // function dragEnded(): any {
-      //   svg.attr('cursor', 'grab');
-      // }
-
-      // Zoom Data from Canvas
-
-      // let test: any = document.getElementById('canvas').children[0];
-      // console.log('from canvas', test.transform);
-      // let newX = test.transform.baseVal[0].matrix.e
-      // let newY = test.transform.baseVal[0].matrix.f
-      // let newK = test.transform.baseVal[1].matrix.a
-      // console.log(newX)
-      // console.log(newY)
-      // console.log(newK)
+    
 
       // call update on node click
       update(root);

--- a/src/app/components/Map.tsx
+++ b/src/app/components/Map.tsx
@@ -12,14 +12,14 @@ const Map = (props) => {
   const { snapshot, snapshots } = props;
   const lastSnap = snapshots.length - 1;
 
-  let width = 1800;
-  let height = 900;
-  let margin = { top: 10, right: 120, bottom: 10, left: 120 };
-  let dy = 100;
-  let dx = 76;
-  let data = snapshots[lastSnap];
-  let tree = d3.tree().nodeSize([dx, dy]);
-  let diagonal = d3
+  const width = 2000;
+  const height = 600;
+  const margin = { top: 10, right: 120, bottom: 10, left: 120 };
+  const dy = 100;
+  const dx = 76;
+  const data = snapshots[lastSnap];
+  const tree = d3.tree().nodeSize([dx, dy]);
+  const diagonal = d3
     .linkHorizontal()
     .x((d) => d.y)
     .y((d) => d.x);
@@ -27,12 +27,11 @@ const Map = (props) => {
  
 
   useEffect(() => {
-    
+    document.getElementById('canvas').innerHTML = '_';
     return makeChart();
   });
 
   const makeChart = () => {
-    document.getElementById('canvas').innerHTML = '';
 
     const root = d3.hierarchy(data);
 
@@ -41,23 +40,13 @@ const Map = (props) => {
     root.descendants().forEach((d, i) => {
       d.id = i;
       d._children = d.children;
-      // if (d.depth && d.data.name.length !== 7) d.children = null;
+       if (d.depth === 9) d.children = null;
     });
 
     console.log("root", root)
-    // const svgContainer: any = d3
-    //   .select('#canvas')
-    //   .attr('width', width)
-    //   .attr('height', height);
-
-    // const svg = d3
-    //   .create('svg')
-    //   .attr('viewBox', [-margin.left, -margin.top, width, dx])
-    //   .style('font', '10px sans-serif')
-    //   .style('user-select', 'none');
-
+   
     const svg = d3
-       .select('#canvas')
+      .select('#canvas')
       .attr('width', width)
       .attr('height', height)
     //   .attr('viewBox', [-margin.left, -margin.top, width, dx])
@@ -68,7 +57,7 @@ const Map = (props) => {
       .append('g')
       .attr('fill', 'none')
       .attr('stroke', '#555')
-      .attr('stroke-opacity', 0.4)
+      .attr('stroke-opacity', 0.9)
       .attr('stroke-width', 1.5);
 
     const gNode = svg
@@ -92,7 +81,7 @@ const Map = (props) => {
         if (node.x > right.x) right = node;
       });
 
-      const height = right.x - left.x + margin.top + margin.bottom;
+     const height = right.x - left.x + margin.top + margin.bottom;
 
       const transition = svg
         .transition()
@@ -109,7 +98,7 @@ const Map = (props) => {
         .append('g')
         .attr('transform', (d) => `translate(${source.y0},${source.x0})`)
         .attr('fill-opacity', 0)
-        .attr('stroke-linejoin', 'round')
+       // .attr('stroke-linejoin', 'round')
         .attr('stroke-opacity', 1)
         .on('click', (d) => {
           d.children = d.children ? null : d._children;
@@ -118,10 +107,11 @@ const Map = (props) => {
 
       nodeEnter
         .append('circle')
-        .attr('r', 15)
+        .attr('r', 10)
         .attr('fill', (d) => (d._children ?  '#46edf2': '#95B6B7' ))
-        .attr('stroke-linejoin', 'round')
-        .attr('stroke-width', 10);
+        //.attr('stroke-linejoin', 'round')
+        .attr('stroke-width', 10)
+        .attr('stroke-opacity', 1);
        
 
       nodeEnter
@@ -130,15 +120,15 @@ const Map = (props) => {
           .attr('x', (d: any) => (d.children ? -50 : 50))
           .attr('text-anchor', (d: any) => (d.children ? 'end' : 'start'))
           .text((d: any) => d.data.name)
-          .style('font-size', `1rem`)
+          .style('font-size', `.8rem`)
           .style('fill', 'white')
           .clone(true)
           .lower()
+          .attr("stroke-linejoin", "round")
           .attr('stroke', '#646464')
           .attr('stroke-width', 2);
         
 
-        console.log("119")
       // Transition nodes to their new position.
       const nodeUpdate = node
         .merge(nodeEnter)
@@ -163,7 +153,7 @@ const Map = (props) => {
       const linkEnter = link
         .enter()
         .append('path')
-        .selectAll('path')
+        //.selectAll('path')
         .attr('d', (d) => {
           const o = { x: source.x0, y: source.y0 };
           return diagonal({ source: o, target: o });
@@ -187,6 +177,9 @@ const Map = (props) => {
         d.x0 = d.x;
         d.y0 = d.y;
       });
+
+    }
+  
          //______________ZOOM______________\\
 
     // Sets starting zoom but breaks keeping currents zoom on state change
@@ -198,20 +191,19 @@ const Map = (props) => {
     //   d3.zoomIdentity.translate(150, 250).scale(0.2)
     // );
 
-    // allows the canvas to be zoom-able
+  // allows the canvas to be zoom-able
     svg.call(
       d3
         .zoom()
-        .scaleExtent([0.05, 0.9]) // [zoomOut, zoomIn]
+        .scaleExtent([0.15, 1.5]) // [zoomOut, zoomIn]
         .on('zoom', zoomed)
     );
     function zoomed(d: any) {
       svg.attr('transform', d3.event.transform);
     }
 
-    //_____________DRAG_____________\\
-    // allows the canvas to be draggable
-   svg.call(
+      // allows the canvas to be draggable
+    svg.call(
       d3
         .drag()
         .on('start', dragStarted)
@@ -221,7 +213,7 @@ const Map = (props) => {
 
     function dragStarted(): any {
       d3.select(this).raise();
-      svg.attr('cursor', 'grabbing');
+     svg.attr('cursor', 'grabbing');
     }
     function dragged(d: any): any {
       d3.select(this)
@@ -231,8 +223,8 @@ const Map = (props) => {
     function dragEnded(): any {
       svg.attr('cursor', 'grab');
     }
-    }
-   
+
+
 
     update(root);
   };
@@ -390,12 +382,10 @@ const Map = (props) => {
   //   }
   // });
 
-  console.log("Return")
   return (
     <div data-testid="canvas">
   
         <svg id="canvas"></svg>
-        hi
       </div>
    
   );

--- a/src/app/components/Map.tsx
+++ b/src/app/components/Map.tsx
@@ -9,7 +9,7 @@ import * as d3 from 'd3';
 
 const Map = (props) => {
   //import props
-  const { viewIndex, snapshots } = props;
+  const { viewIndex, snapshots ,x ,y, k, setZoomState} = props;
   let lastSnap: number | null = null;
   if (viewIndex < 0) lastSnap = snapshots.length - 1;
   else lastSnap = viewIndex;
@@ -18,17 +18,6 @@ const Map = (props) => {
   const width: number = 900;
   const height: number = 600;
   let data = snapshots[lastSnap];
-
-  const [{ x, y, k }, setZoomState]: any = useState({
-    x: 150,
-    y: 250,
-    k: 0.75,
-  });
-
-  // useEffect(() => {
-  //   setZoomState(d3.zoomTransform(d3.select('#canvas').node()));
-  // }, [data]);
-
 
   useEffect(() => {
     document.getElementById('canvas').innerHTML = '_';

--- a/src/app/components/Map.tsx
+++ b/src/app/components/Map.tsx
@@ -40,16 +40,14 @@ const Map = (props) => {
 
     // creating the tree map
     const treeMap: any = d3.tree().nodeSize([width, height]);
-
     // creating the nodes of the tree
     const hierarchyNodes: any = d3.hierarchy(snapshots[lastSnap]);
-
     // calling the tree function with nodes created from data
     const finalMap: any = treeMap(hierarchyNodes);
-
-    // renders a flat array of objects containing all parent-child links
     // renders the paths onto the component
     let paths: any = finalMap.links();
+    // returns a flat array of objects containing all the nodes and their information
+    let nodes: any = hierarchyNodes.descendants();
 
     // this creates the paths to each node and its contents in the tree
     g.append('g')
@@ -68,8 +66,7 @@ const Map = (props) => {
           .y((d: any) => d.x)
       );
 
-    // returns a flat array of objects containing all the nodes and their information
-    let nodes: any = hierarchyNodes.descendants();
+  
 
     // this segment places all the nodes on the canvas
     const node: any = g
@@ -124,6 +121,31 @@ const Map = (props) => {
       d3.select(`#popup${i}`).remove();
     });
 
+    
+
+    //______________ZOOM______________\\
+
+    // Sets starting zoom but breaks keeping currents zoom on state change
+
+    // let zoom = d3.zoom().on('zoom', zoomed);
+    // svgContainer.call(
+    //   zoom.transform,
+    //   // Changes the initial view, (left, top)
+    //   d3.zoomIdentity.translate(150, 250).scale(0.2)
+    // );
+
+    // allows the canvas to be zoom-able
+    svgContainer.call(
+      d3
+        .zoom()
+        .scaleExtent([0.05, 0.9]) // [zoomOut, zoomIn]
+        .on('zoom', zoomed)
+    );
+    function zoomed(d: any) {
+      g.attr('transform', d3.event.transform);
+    }
+
+    //_____________DRAG_____________\\
     // allows the canvas to be draggable
     node.call(
       d3
@@ -133,38 +155,15 @@ const Map = (props) => {
         .on('end', dragEnded)
     );
 
-    // allows the canvas to be zoom-able
-    // d3 zoom functionality
-    let zoom = d3.zoom().on('zoom', zoomed);
-    svgContainer.call(
-      zoom.transform,
-      // Changes the initial view, (left, top)
-      d3.zoomIdentity.translate(150, 250).scale(0.2)
-    );
-    // allows the canvas to be zoom-able
-    svgContainer.call(
-      d3
-        .zoom()
-        .scaleExtent([0.05, 0.9]) // [zoomOut, zoomIn]
-        .on('zoom', zoomed)
-    );
-    // helper function that allows for zooming
-    function zoomed(d: any) {
-      g.attr('transform', d3.event.transform);
-    }
-
-    // helper functions that help with dragging functionality
     function dragStarted(): any {
       d3.select(this).raise();
       g.attr('cursor', 'grabbing');
     }
-
     function dragged(d: any): any {
       d3.select(this)
         .attr('dx', (d.x = d3.event.x))
         .attr('dy', (d.y = d3.event.y));
     }
-
     function dragEnded(): any {
       g.attr('cursor', 'grab');
     }

--- a/src/app/components/PerfView.tsx
+++ b/src/app/components/PerfView.tsx
@@ -45,8 +45,8 @@ const PerfView = (props: PerfViewProps) => {
   if (viewIndex < 0) indexToDisplay = snapshots.length - 1;
   else indexToDisplay = viewIndex;
 
-  console.log('SNAPSHOTS IN PERF VIEW', snapshots);
-  console.log('VIEW INDEX', indexToDisplay);
+  //console.log('SNAPSHOTS IN PERF VIEW', snapshots);
+  //console.log('VIEW INDEX', indexToDisplay);
 
   // Set up color scaling function
   const colorScale = d3

--- a/src/app/components/StateRoute.tsx
+++ b/src/app/components/StateRoute.tsx
@@ -40,7 +40,7 @@ const StateRoute = (props: StateRouteProps) => {
   const { snapshot, hierarchy, snapshots, viewIndex } = props;
   const [noRenderData, setNoRenderData] = useState(false);
 
-  //Test Map
+  //Map
   const renderMap = () => {
     if (hierarchy) {
       return <Map viewIndex={viewIndex} snapshots={snapshots} />;

--- a/src/app/components/StateRoute.tsx
+++ b/src/app/components/StateRoute.tsx
@@ -15,6 +15,8 @@ import Tree from './Tree';
 import Map from './Map';
 import PerfView from './PerfView';
 
+
+
 const Chart = require('./Chart').default;
 
 const ErrorHandler = require('./ErrorHandler').default;
@@ -39,7 +41,11 @@ interface StateRouteProps {
 const StateRoute = (props: StateRouteProps) => {
   const { snapshot, hierarchy, snapshots, viewIndex } = props;
   const [noRenderData, setNoRenderData] = useState(false);
-
+  const [{ x, y, k }, setZoomState]: any = useState({
+    x: 150,
+    y: 250,
+    k: 0.75,
+  });
   //Map
   const renderMap = () => {
     if (hierarchy) {
@@ -124,7 +130,7 @@ const StateRoute = (props: StateRouteProps) => {
         </NavLink>
       </div>
       <Switch>
-        <Route path="/map" render={renderMap} />
+        <Route path="/map" render ={(props) => <Map viewIndex={viewIndex} snapshots={snapshots} x={x} y={y} k={k} setZoomState={setZoomState}/> } />
         <Route path="/chart" render={renderChart} />
         <Route path="/performance" render={renderPerfView} />
         <Route path="/" render={renderTree} />

--- a/src/app/components/StateRoute.tsx
+++ b/src/app/components/StateRoute.tsx
@@ -49,7 +49,7 @@ const StateRoute = (props: StateRouteProps) => {
   //Map
   const renderMap = () => {
     if (hierarchy) {
-      return <Map viewIndex={viewIndex} snapshots={snapshots} />;
+      return <Map viewIndex={viewIndex} snapshots={snapshots} x={x} y={y} k={k} setZoomState={setZoomState} />;
     }
     return <div className="noState">{NO_STATE_MSG}</div>;
   };
@@ -130,7 +130,7 @@ const StateRoute = (props: StateRouteProps) => {
         </NavLink>
       </div>
       <Switch>
-        <Route path="/map" render ={(props) => <Map viewIndex={viewIndex} snapshots={snapshots} x={x} y={y} k={k} setZoomState={setZoomState}/> } />
+        <Route path="/map" render={renderMap}  />
         <Route path="/chart" render={renderChart} />
         <Route path="/performance" render={renderPerfView} />
         <Route path="/" render={renderTree} />

--- a/src/app/components/StateRoute.tsx
+++ b/src/app/components/StateRoute.tsx
@@ -43,7 +43,7 @@ const StateRoute = (props: StateRouteProps) => {
   //Test Map
   const renderMap = () => {
     if (hierarchy) {
-      return <Map snapshot={snapshot} snapshots={snapshots} />;
+      return <Map viewIndex={viewIndex} snapshots={snapshots} />;
     }
     return <div className="noState">{NO_STATE_MSG}</div>;
   };
@@ -67,12 +67,10 @@ const StateRoute = (props: StateRouteProps) => {
     }
     return <div className="noState">{NO_STATE_MSG}</div>;
   };
-  console.log('NORENDER DATA', noRenderData);
+  
   let perfChart;
   if (true) {
-    console.log('ViewINDex', viewIndex);
-    console.log('snapshots', snapshots);
-    console.log('setnorenderdata', setNoRenderData);
+    
     perfChart = (
       <PerfView
         viewIndex={viewIndex}


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply. -->

- [x] Bugfix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [x] Refactor (change which changes the codebase without affecting its external behavior)
- [x] Non-breaking change (fix or feature –that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to **not** work as expected)

## Purpose
To improve the functionality along with the look and feel of our Map function.
Add the ability for users to collapse tree nodes.
Allow for persistent zoom state after updating the DOM, changing tabs, or changing state snapshot.
<!--- Describe the problem or feature. Link to the issue(s) fixed by this pull request if applicable. -->

## Approach
Created function for storing and updating zoom state of D3 visualization. 
Moved state up the component chain to store in StateRoutes.tsx to allow for persistent zoom state on tab switch. 
Used "onmouseup" in the zoomed function to reset the zoom state.
Added update method to D3 to allow for collapse of tree nodes.

<!--- How does your change address the problem? -->

## Learning
Collapse functionality modeled after https://observablehq.com/@d3/collapsible-tree
<!--- Describe the research stage. Link to any blog posts, video, patterns, libraries, addons, or other resources that helped you to solve this problem. -->

## Screenshot(s)
Persistent Zoom
![Screen Shot 2020-08-26 at 8 01 15 PM](https://user-images.githubusercontent.com/62725736/91380711-834d7600-e7da-11ea-9638-0c5e2ddde674.png)
![Screen Shot 2020-08-26 at 8 01 20 PM](https://user-images.githubusercontent.com/62725736/91380721-85afd000-e7da-11ea-9338-83c0fbb57ed3.png)

Collapsable Nodes
![Screen Shot 2020-08-26 at 8 02 08 PM](https://user-images.githubusercontent.com/62725736/91380746-96f8dc80-e7da-11ea-9770-44082f34f258.png)
![Screen Shot 2020-08-26 at 8 02 04 PM](https://user-images.githubusercontent.com/62725736/91380748-995b3680-e7da-11ea-923c-c3b2a6df23ac.png)

Zoom State now in StateRoute.tsx
![Screen Shot 2020-08-26 at 8 28 26 PM](https://user-images.githubusercontent.com/62725736/91380848-cf001f80-e7da-11ea-9cdf-791a6c45e8aa.png)

'onmouseup' setting Zoom State
![Screen Shot 2020-08-26 at 8 28 43 PM](https://user-images.githubusercontent.com/62725736/91380866-db847800-e7da-11ea-86e8-60c4d9537d7b.png)

update for collapse function
![Screen Shot 2020-08-26 at 8 28 53 PM](https://user-images.githubusercontent.com/62725736/91380905-f5be5600-e7da-11ea-9f5b-c9a4c8403906.png)




<!--- (if applicable--you can delete otherwise) -->
<!--- Include a screenshot here if the change you made changes the look of the site in any way! -->
