### PR TITLE
Fixed bug where traverseHooks function was not entering its condition to push onto hooksStates

### DIFF
--- a/src/backend/linkFiber.ts
+++ b/src/backend/linkFiber.ts
@@ -139,8 +139,6 @@ function traverseHooks(memoizedState: any): HookStates {
   while (memoizedState && memoizedState.queue) {
     if (
       memoizedState.memoizedState
-      && memoizedState.queue.lastRenderedReducer
-      && memoizedState.queue.lastRenderedReducer.name === 'basicStateReducer'
     ) {
       hooksStates.push({
         component: memoizedState.queue,


### PR DESCRIPTION
Removed 2 lines that were checking for properties that no longer exist on the fiber node object