### PR TITLE
added server close to link fiber tests

### DIFF
--- a/src/backend/__tests__/linkFiber.test.tsx
+++ b/src/backend/__tests__/linkFiber.test.tsx
@@ -105,5 +105,4 @@ xdescribe('unit test for linkFiber', () => {
   });
 });
 
-
- 
+SERVER.close();


### PR DESCRIPTION
### PROBLEM
- Travis CI tests arent finishing because server wont close
### SOLUTION
- Added server.close call at end of linkFiber test file.