### PR TITLE
Re-ordered default component view to give preference to Performance and Map

### DIFF
--- a/src/app/components/ComponentMap.tsx
+++ b/src/app/components/ComponentMap.tsx
@@ -188,7 +188,7 @@ export default function ComponentMap({
                     left = node.y;
                   }
 
-                  //mousing controls
+                  //mousing controls & Tooltip display logic
                   const handleMouseOver = (event) => {
                     () => dispatch(onHover(node.data.rtid));
                     const coords = localPoint(event.target.ownerSVGElement, event);

--- a/src/app/components/StateRoute.tsx
+++ b/src/app/components/StateRoute.tsx
@@ -139,6 +139,7 @@ const StateRoute = (props: StateRouteProps) => {
       <NavLink
           className="router-link"
           activeClassName="is-active"
+          exact
           to="/"
         >
           Performance
@@ -156,7 +157,6 @@ const StateRoute = (props: StateRouteProps) => {
         <NavLink
           className="router-link"
           activeClassName="is-active"
-          exact
           to="/tree"
         >
           Tree

--- a/src/app/components/StateRoute.tsx
+++ b/src/app/components/StateRoute.tsx
@@ -139,12 +139,13 @@ const StateRoute = (props: StateRouteProps) => {
       <NavLink
           className="router-link"
           activeClassName="is-active"
-          exact
-          to="/"
+          exact to="/"
         >
           Performance
         </NavLink>
-        <NavLink className="router-link" activeClassName="is-active" to="/map">
+        <NavLink className="router-link" 
+        activeClassName="is-active" 
+        to="/map">
           Map
         </NavLink>
         <NavLink
@@ -177,8 +178,8 @@ const StateRoute = (props: StateRouteProps) => {
         <Route path="/map" render={renderComponentMap} />
         <Route path="/history" render={renderHistory} />
         <Route path="/relationship" render={renderAtomsRelationship} />
-        <Route path="/" render={renderPerfView} />
         <Route path="/tree" render={renderTree} />
+        <Route path="/" render={renderPerfView} />
       </Switch>
     </Router>
   );

--- a/src/app/components/StateRoute.tsx
+++ b/src/app/components/StateRoute.tsx
@@ -136,13 +136,15 @@ const StateRoute = (props: StateRouteProps) => {
   return (
     <Router>
       <div className="navbar">
-        <NavLink
+      <NavLink
           className="router-link"
           activeClassName="is-active"
-          exact
           to="/"
         >
-          Tree
+          Performance
+        </NavLink>
+        <NavLink className="router-link" activeClassName="is-active" to="/map">
+          Map
         </NavLink>
         <NavLink
           className="router-link"
@@ -151,8 +153,13 @@ const StateRoute = (props: StateRouteProps) => {
         >
           History
         </NavLink>
-        <NavLink className="router-link" activeClassName="is-active" to="/map">
-          Map
+        <NavLink
+          className="router-link"
+          activeClassName="is-active"
+          exact
+          to="/tree"
+        >
+          Tree
         </NavLink>
 
         {isRecoil && (
@@ -165,20 +172,13 @@ const StateRoute = (props: StateRouteProps) => {
           </NavLink>
         )}
 
-        <NavLink
-          className="router-link"
-          activeClassName="is-active"
-          to="/performance"
-        >
-          Performance
-        </NavLink>
       </div>
       <Switch>
         <Route path="/map" render={renderComponentMap} />
         <Route path="/history" render={renderHistory} />
         <Route path="/relationship" render={renderAtomsRelationship} />
-        <Route path="/performance" render={renderPerfView} />
-        <Route path="/" render={renderTree} />
+        <Route path="/" render={renderPerfView} />
+        <Route path="/tree" render={renderTree} />
       </Switch>
     </Router>
   );


### PR DESCRIPTION
## Types of changes
- [x] Bugfix (change which fixes an issue)
- [] New feature (change which adds functionality)
- [x] Refactor (change which changes the codebase without affecting its external behavior)
- [x] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
-Re-ordered default component view to give preference to Performance and Map

## Approach
-Tree view was the default on app open
-Relegated Tree to the last spot to give preference to updated Performance and Map
-Performance set as new default on open

Co-authored-by: kev-ngo <kevinngo.cal@gmail.com>
Co-authored-by: CourageWolf <marchofthepenguins1@gmail.com>
Co-authored-by: DennisLpz <dnnis.lpz@gmail.com>
Co-authored-by: demircaner <canerdemir62@gmail.com>