### PR TITLE
fix: removed bug where all object properties were being assigned to undefined

### DIFF
--- a/src/backend/timeJump.ts
+++ b/src/backend/timeJump.ts
@@ -44,9 +44,9 @@ export default mode => {
         prevState => {
           Object.keys(prevState).forEach(key => {
             // the if conditional below does not appear to ever be reached if all states are defined - leaving code in just in case codebases do have undefined states
-            if (target.state[key] !== undefined) {
-              target.state[key] = undefined;
-            }
+            // if (target.state[key] !== undefined) {
+            //   target.state[key] = undefined;
+            // }
           });
           return target.state;
         },


### PR DESCRIPTION
Previously all object properties for previous state were getting reassigned to "undefined", making any application that stored state in an object crash when you tried to time travel backwards.

Commented out the bug. Need to test if it was there for a specific reason