### PR TITLE
feat: swapped the default graph orientation from horizontal to vertical

### DIFF
--- a/src/app/components/StateRoute/ComponentMap/ComponentMap.tsx
+++ b/src/app/components/StateRoute/ComponentMap/ComponentMap.tsx
@@ -47,7 +47,7 @@ export default function ComponentMap({
 }: LinkTypesProps): JSX.Element {
   // importing custom hooks for the selection tabs.
   const [layout, setLayout] = useState('cartesian');
-  const [orientation, setOrientation] = useState('horizontal');
+  const [orientation, setOrientation] = useState('vertical');
   const [linkType, setLinkType] = useState('diagonal');
   const [stepPercent, setStepPercent] = useState(10);
   const [Tooltip, setTooltip] = useState(false);

--- a/src/app/components/StateRoute/ComponentMap/LinkControls.tsx
+++ b/src/app/components/StateRoute/ComponentMap/LinkControls.tsx
@@ -89,8 +89,8 @@ export default function LinkControls({
         disabled={layout === 'polar'}
         style={dropDownStyle}
       >
-        <option value="horizontal">Horizontal</option>
         <option value="vertical">Vertical</option>
+        <option value="horizontal">Horizontal</option>
       </select>
       &nbsp;&nbsp;
 


### PR DESCRIPTION
Set the default orientation of the dropdown to "vertical", changed the order of the options in the dropdown to reflect that.