### PR TITLE
Remove @emotion library from Reactime

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,3 @@
 {
-  "presets": ["airbnb", "@babel/preset-typescript"],
-  "plugins": ["@emotion"]
+  "presets": ["airbnb", "@babel/preset-typescript"]
 }

--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
     "@babel/preset-env": "^7.12.7",
     "@babel/preset-react": "^7.12.7",
     "@babel/preset-typescript": "^7.21.5",
-    "@emotion/babel-plugin": "^11.7.2",
     "@inrupt/jest-jsdom-polyfills": "^1.6.2",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^13.4.0",
@@ -152,8 +151,6 @@
     "webpack-cli": "^3.3.12"
   },
   "dependencies": {
-    "@emotion/react": "^11.9.0",
-    "@emotion/styled": "^11.8.1",
     "@fortawesome/fontawesome-free": "^5.15.1",
     "@fortawesome/fontawesome-svg-core": "^1.2.32",
     "@fortawesome/free-regular-svg-icons": "^5.15.1",

--- a/src/app/components/Loader.tsx
+++ b/src/app/components/Loader.tsx
@@ -17,7 +17,7 @@ const handleResult = (result: boolean): JSX.Element =>
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const Loader = ({ loading, result }): JSX.Element =>
   loading ? (
-    <ClipLoader color='#123abc' size={30} loading={loading} />
+    <ClipLoader color='#123abc' size={30} loading={loading} style={{ display: "inline", margin: "0 auto" }}/>
   ) : (
     handleResult(result)
   );

--- a/src/app/components/Loader.tsx
+++ b/src/app/components/Loader.tsx
@@ -1,15 +1,9 @@
 // /* eslint-disable react/prop-types */
 
 import React from 'react';
-import { css, SerializedStyles } from '@emotion/react';
 import { ClipLoader } from 'react-spinners';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCheck, faExclamationCircle } from '@fortawesome/free-solid-svg-icons';
-
-const override: SerializedStyles = css`
-  display: inline;
-  margin: 0 auto;
-`;
 
 // Displays the result of the check when loading is done
 const handleResult = (result: boolean): JSX.Element =>
@@ -23,7 +17,7 @@ const handleResult = (result: boolean): JSX.Element =>
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const Loader = ({ loading, result }): JSX.Element =>
   loading ? (
-    <ClipLoader color='#123abc' css={override} size={30} loading={loading} />
+    <ClipLoader color='#123abc' size={30} loading={loading} />
   ) : (
     handleResult(result)
   );


### PR DESCRIPTION
The @emotion library has @emotion/core has a dependency and this is incompatible with React v18. Previous versions of Reactime used npm install --force as a workaround for the deprecated package, but this is no longer a viable solution. Currently, Webpack cannot create the production or dev build while @emotion is configured. As a result, we are removing @emotion from Reactime.